### PR TITLE
onSlidingComplete callback now gets called AFTER the state is synchro…

### DIFF
--- a/SnapSlider.js
+++ b/SnapSlider.js
@@ -70,10 +70,11 @@ var SnapSlider = React.createClass({
         } else {
             this.setState({adjustSign: 1});
         }
-        this.setState({value: value, item: i});
+        this.setState({value: value, item: i}, () => 
+            //callback
+            this.props.onSlidingComplete()
+        );
 
-        //callback
-        this.props.onSlidingComplete();
     },
     /*
     componentWillUpdate() {


### PR DESCRIPTION
…nized; Fixes the issue where the state seems to be an event behind when accessing the component's state in the onSlidingComplete callback function.

This is a very small fix I know, but I had to edit it this way in one of my recent projects. ReactNative is a framework with alot of new people learning it, and they might be really lost on why their state is 1 event behind. It isn't the easiest fix to spot for new people as well.